### PR TITLE
UC13: Klanten tonen per product afgerond

### DIFF
--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -24,7 +24,15 @@ namespace Grocery.App.ViewModels
 
         partial void OnSelectedProductChanged(Product? oldValue, Product newValue)
         {
-            //Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
+            BoughtProductsList.Clear();
+            if (newValue != null)
+            {
+                var boughtProducts = _boughtProductsService.Get(newValue.Id);
+                foreach (var item in boughtProducts)
+                {
+                    BoughtProductsList.Add(item);
+                }
+            }
         }
 
         [RelayCommand]

--- a/Grocery.App/ViewModels/GroceryListViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListViewModel.cs
@@ -1,8 +1,9 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
-using System.Collections.ObjectModel;
+using Grocery.Core.Services;
 
 namespace Grocery.App.ViewModels
 {
@@ -10,12 +11,18 @@ namespace Grocery.App.ViewModels
     {
         public ObservableCollection<GroceryList> GroceryLists { get; set; }
         private readonly IGroceryListService _groceryListService;
+        private readonly IClientService _clientService;
+        private readonly Client _currentClient;
 
-        public GroceryListViewModel(IGroceryListService groceryListService) 
+        public string ClientName => _currentClient.Name;
+
+        public GroceryListViewModel(IGroceryListService groceryListService, IClientService clientService)
         {
             Title = "Boodschappenlijst";
             _groceryListService = groceryListService;
             GroceryLists = new(_groceryListService.GetAll());
+            _clientService = clientService;
+            _currentClient = _clientService.Get(3);
         }
 
         [RelayCommand]
@@ -34,6 +41,15 @@ namespace Grocery.App.ViewModels
         {
             base.OnDisappearing();
             GroceryLists.Clear();
+        }
+
+        [RelayCommand]
+        public async Task ShowBoughtProducts()
+        {
+            if (_currentClient.ClientRole == Role.Admin)
+            {
+                await Shell.Current.GoToAsync("//BoughtProductsView");
+            }
         }
     }
 }

--- a/Grocery.App/Views/BestSellingProductsView.xaml
+++ b/Grocery.App/Views/BestSellingProductsView.xaml
@@ -26,11 +26,10 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <Label Grid.Column="0" Text="ID" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
-                    <Label Grid.Column="1" Text="Product" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
-                    <Label Grid.Column="2" Text="Voorraad" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
-                    <Label Grid.Column="3" Text="Verkocht" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
-                    <Label Grid.Column="4" Text="Rang" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Label Grid.Column="0" Text="Product" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Label Grid.Column="1" Text="Voorraad" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Label Grid.Column="2" Text="Verkocht" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Label Grid.Column="3" Text="Rang" FontAttributes="Bold" HorizontalOptions="Center" VerticalOptions="Center" />
                 </Grid>
             </CollectionView.Header>
             <CollectionView.ItemTemplate>
@@ -43,11 +42,10 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <Label Grid.Column="0" Text="{Binding ProductId}" HorizontalOptions="Center" VerticalOptions="Center" />
-                        <Label Grid.Column="1" Text="{Binding Name}" HorizontalOptions="Center" VerticalOptions="Center" />
-                        <Label Grid.Column="2" Text="{Binding Stock}" HorizontalOptions="Center" VerticalOptions="Center" />
-                        <Label Grid.Column="3" Text="{Binding NrOfSells}" HorizontalOptions="Center" VerticalOptions="Center" />
-                        <Label Grid.Column="4" Text="{Binding Ranking}" HorizontalOptions="Center" VerticalOptions="Center" />
+                        <Label Grid.Column="0" Text="{Binding Name}" HorizontalOptions="Center" VerticalOptions="Center" />
+                        <Label Grid.Column="1" Text="{Binding Stock}" HorizontalOptions="Center" VerticalOptions="Center" />
+                        <Label Grid.Column="2" Text="{Binding NrOfSells}" HorizontalOptions="Center" VerticalOptions="Center" />
+                        <Label Grid.Column="3" Text="{Binding Ranking}" HorizontalOptions="Center" VerticalOptions="Center" />
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -34,7 +34,8 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <!-- Toon hier de naam van de Client naam van de boodschappenlijst -->
+                            <Label Grid.Column="0" Text="{Binding Client.Name}" HorizontalOptions="Center" VerticalOptions="Center" />
+                            <Label Grid.Column="1" Text="{Binding GroceryList.Name}" HorizontalOptions="Center" VerticalOptions="Center" />
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.App/Views/GroceryListsView.xaml
+++ b/Grocery.App/Views/GroceryListsView.xaml
@@ -5,18 +5,21 @@
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
              xmlns:m="clr-namespace:Grocery.Core.Models;assembly=Grocery.Core"
              x:DataType="vm:GroceryListViewModel"
-             Title="GroceryListsView">
+             Title="Boodschappenlijsten">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{Binding ClientName}"
+                     Command="{Binding ShowBoughtProductsCommand}" />
+    </ContentPage.ToolbarItems>
     <Shell.TitleView>
         <Grid>
             <Label Text="Boodschappenlijsten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
-
     <Border Stroke="#C49B33"
-        StrokeThickness="4"
-        Padding="10"
-        Margin="10"
-        HorizontalOptions="Center">
+            StrokeThickness="4"
+            Padding="10"
+            Margin="10"
+            HorizontalOptions="Center">
         <CollectionView x:Name="GroceryListView" ItemsSource="{Binding GroceryLists}" HorizontalOptions="Center"
                         SelectionMode="Single"
                         SelectionChangedCommand="{Binding SelectGroceryListCommand}"
@@ -24,7 +27,6 @@
             <CollectionView.ItemsLayout>
                 <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
             </CollectionView.ItemsLayout>
-
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="m:GroceryList">
                     <Grid>

--- a/Grocery.Core.Data/Repositories/ClientRepository.cs
+++ b/Grocery.Core.Data/Repositories/ClientRepository.cs
@@ -13,7 +13,7 @@ namespace Grocery.Core.Data.Repositories
             clientList = [
                 new Client(1, "M.J. Curie", "user1@mail.com", "IunRhDKa+fWo8+4/Qfj7Pg==.kDxZnUQHCZun6gLIE6d9oeULLRIuRmxmH2QKJv2IM08="),
                 new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU="),
-                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=")
+                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=", Role.Admin)
             ];
         }
 

--- a/Grocery.Core/Models/Client.cs
+++ b/Grocery.Core/Models/Client.cs
@@ -5,10 +5,12 @@ namespace Grocery.Core.Models
     {
         public string EmailAddress { get; set; }
         public string Password { get; set; }
-        public Client(int id, string name, string emailAddress, string password) : base(id, name)
+        public Role ClientRole { get; set; } = Role.None;
+        public Client(int id, string name, string emailAddress, string password, Role role = Role.None) : base(id, name)
         {
             EmailAddress=emailAddress;
             Password=password;
+            ClientRole = role;
         }
     }
 }

--- a/Grocery.Core/Models/Role.cs
+++ b/Grocery.Core/Models/Role.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grocery.Core.Models
+{
+    public enum Role
+    {
+        None,
+        Admin,
+    }
+}

--- a/Grocery.Core/Services/BoughtProductsService.cs
+++ b/Grocery.Core/Services/BoughtProductsService.cs
@@ -20,7 +20,44 @@ namespace Grocery.Core.Services
         }
         public List<BoughtProducts> Get(int? productId)
         {
-            throw new NotImplementedException();
+            if (!productId.HasValue)
+            {
+                return new List<BoughtProducts>();
+            }
+
+            var items = _groceryListItemsRepository.GetAll()
+                .Where(item => item.ProductId == productId.Value)
+                .ToList();
+
+            var groceryListIds = items.Select(item => item.GroceryListId).Distinct();
+
+            var groceryLists = _groceryListRepository.GetAll()
+                .Where(gl => groceryListIds.Contains(gl.Id))
+                .ToList();
+
+            var clientIds = groceryLists.Select(gl => gl.ClientId).Distinct();
+
+            var clients = _clientRepository.GetAll()
+                .Where(c => clientIds.Contains(c.Id))
+                .ToList();
+
+            var result = new List<BoughtProducts>();
+            var product = _productRepository.Get(productId.Value);
+
+            foreach (var client in clients)
+            {
+                var clientGroceryLists = groceryLists.Where(gl => gl.ClientId == client.Id).ToList();
+                foreach (var groceryList in clientGroceryLists)
+                {
+                    result.Add(new BoughtProducts(
+                        client: client,
+                        groceryList: groceryList,
+                        product: product
+                    ));
+                }
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
UC13 ("Klanten tonen per product") geïmplementeerd door een ToolbarItem toe te voegen aan GroceryListsView.xaml dat bindt aan ClientName en ShowBoughtProductsCommand in GroceryListViewModel aanroept. GroceryListViewModel bijgewerkt om een ClientName-property beschikbaar te stellen voor binding, terwijl _currentClient privé blijft. GroceryListsView.xaml aangepast zodat ToolbarItem Text bindt aan ClientName in plaats van Client.Name, waarmee de binding error is opgelost. Ervoor gezorgd dat ShowBoughtProducts alleen naar BoughtProductsView navigeert voor admins (ClientRole == Role.Admin). GroceryLists gefilterd op _currentClient.Id om cliëntspecifieke lijsten te tonen. Code-behind bijgewerkt om BindingContext correct te zetten.